### PR TITLE
Use COMPRESS=LZW and BIGTIFF=IF_SAFER for every raster output

### DIFF
--- a/qgsTreatments.py
+++ b/qgsTreatments.py
@@ -52,7 +52,7 @@ from . import utils, qgsUtils
 
 nodata_val = '-9999'
 MEMORY_LAYER_NAME = 'memory:'
-GTIFF_COPT = qgsUtils.DEFAULT_GTIFF_COPT
+GTIFF_COPT = qgsUtils.GTIFF_COPT
 
 gdal_calc_cmd = None
 gdal_merge_cmd = None

--- a/qgsTreatments.py
+++ b/qgsTreatments.py
@@ -52,6 +52,7 @@ from . import utils, qgsUtils
 
 nodata_val = '-9999'
 MEMORY_LAYER_NAME = 'memory:'
+GTIFF_COPT = qgsUtils.DEFAULT_GTIFF_COPT
 
 gdal_calc_cmd = None
 gdal_merge_cmd = None
@@ -703,7 +704,7 @@ def applyHeatmap(input, output, resolution=5, radius_field=None,
 # Output raster layer is loaded in QGIS if 'load_flag' is True.
 def applyRasterization(in_path,out_path,extent,resolution,
                        field=None,burn_val=None,out_type=Qgis.Float32,
-                       nodata_val=nodata_val,all_touch=False,overwrite=False,options='',
+                       nodata_val=nodata_val,all_touch=False,overwrite=False,
                        context=None,feedback=None):
     TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32',
              'Float64', Qgis.CInt16, Qgis.CInt32, 'CFloat32', 'CFloat64']
@@ -721,7 +722,7 @@ def applyRasterization(in_path,out_path,extent,resolution,
                    'INPUT' : in_path,
                    #'INVERT' : False,
                    'NODATA' : nodata_val,
-                   'OPTIONS' : options,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'OUTPUT' : out_path,
                    'UNITS' : 1, 
                    'WIDTH' : resolution }
@@ -765,6 +766,7 @@ def applyWarpReproject(in_path,out_path,resampling_mode='near',dst_crs=None,
                    'INPUT' : in_path,
                    'NODATA' : nodata_val,
                    'OUTPUT' : out_path,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'RESAMPLING' : mode_val,
                    'SOURCE_CRS' : src_crs,
                    'TARGET_CRS' : dst_crs,
@@ -783,6 +785,7 @@ def applyTranslate(in_path,out_path,data_type=USE_INPUT_TYPE,nodata_val=nodata_v
                    'NODATA' : nodata_val,
                    'OPTIONS': options,
                    'OUTPUT' : out_path,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'TARGET_CRS' : None }
     return applyProcessingAlg("gdal","translate",parameters,context,feedback)
 
@@ -800,7 +803,7 @@ def clipRasterFromVector(raster_path,vector_path,out_path,
                    'KEEP_RESOLUTION' : keep_res,
                    'MASK' : vector_path,
                    'NODATA' : nodata,
-                   #'OPTIONS' : '',
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'OUTPUT' : out_path }
     if resolution:
         parameters['SET_RESOLUTION'] = True
@@ -831,13 +834,14 @@ def clipRasterAllTouched(raster_path,vector_path,dst_crs,
                    'RESAMPLING' : 0,
                    'TARGET_CRS' : dst_crs,
                    'TARGET_RESOLUTION' : resolution,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'EXTRA' : extra_params }
     return applyProcessingAlg("gdal","warpreproject",parameters,context,feedback)
     
 
     
 def applyMergeRaster(files,output,nodata_val=nodata_val,out_type=Qgis.Float32,
-                     nodata_input=None,options='',context=None,feedback=None):
+                     nodata_input=None,context=None,feedback=None):
     TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
     feedbacks.setSubText("Merge raster")
     parameters = {
@@ -846,7 +850,7 @@ def applyMergeRaster(files,output,nodata_val=nodata_val,out_type=Qgis.Float32,
             'INPUT': files,
             'NODATA_INPUT': nodata_input,
             'NODATA_OUTPUT': nodata_val,
-            'OPTIONS': options,
+            'OPTIONS' : '|'.join(GTIFF_COPT),
             'PCT': False,
             'SEPARATE': True,
             'OUTPUT': output
@@ -864,6 +868,7 @@ def applyRasterCalcProc(input_a,output,expr,
                    'INPUT_A' : input_a,
                    'NO_DATA' : nodata_val,
                    'OUTPUT' : output,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'RTYPE' : qgsTypeToInt(out_type,shift=True) }
     return applyProcessingAlg("gdal","rastercalculator",parameters,context,feedback)
     
@@ -906,6 +911,7 @@ def applyRasterCalcAB(input_a,input_b,output,expr,
                    'INPUT_B' : input_b,
                    'NO_DATA' : nodata_val,
                    'OUTPUT' : output,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'RTYPE' : qgsTypeToInt(out_type,shift=True) }
     return applyProcessingAlg("gdal","rastercalculator",parameters,
                context=context,feedback=feedback)
@@ -953,6 +959,7 @@ def applyRasterCalcAB_ABNull(input_a,input_b,output,expr,
                    'INPUT_B' : nonull_b,
                    'NO_DATA' : nodata_val,
                    'OUTPUT' : nonull_ab,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'RTYPE' : qgsTypeToInt(out_type,shift=True) }
     applyProcessingAlg("gdal","rastercalculator",parameters,
         context=context,feedback=feedback)
@@ -992,6 +999,7 @@ def applyProximity(input,output,classes='',band=1,units=0,context=None,feedback=
         'OUTPUT' : output,
         'VALUES' : classes,
         'BAND' : band,
+        'OPTIONS' : '|'.join(GTIFF_COPT),
         'UNITS' : units }
     return applyProcessingAlg("gdal","proximity",parameters,context,feedback)
   
@@ -1027,11 +1035,12 @@ def applyVRandom(vector_layer,nb_points,output,context=None,feedback=None):
 # Output format is Integer32.
 def applyResample(in_path,out_path,context=None,feedback=None):
     parameters = {'input' : in_path,
-                   'output' : out_path,
-                   '--overwrite' : True,
-                   'GRASS_REGION_CELLSIZE_PARAMETER' : 50,
-                   'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
-                   'GRASS_MIN_AREA_PARAMETER' : 0}
+                  'output' : out_path,
+                  '--overwrite' : True,
+                  'GRASS_REGION_CELLSIZE_PARAMETER' : 50,
+                  'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
+                  'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
+                  'GRASS_MIN_AREA_PARAMETER' : 0}
     return applyGrassAlg("r.resample",parameters,context,feedback)
     
 def applyReclassGdal(in_path,out_path,rules_file,title,context=None,feedback=None):
@@ -1039,9 +1048,10 @@ def applyReclassGdal(in_path,out_path,rules_file,title,context=None,feedback=Non
                   'output' : out_path,
                   'rules' : rules_file,
                   'title' : title,
-                   'GRASS_REGION_CELLSIZE_PARAMETER' : 50,
-                   'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
-                   'GRASS_MIN_AREA_PARAMETER' : 0}
+                  'GRASS_REGION_CELLSIZE_PARAMETER' : 50,
+                  'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
+                  'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
+                  'GRASS_MIN_AREA_PARAMETER' : 0}
     return applyGrassAlg("r.reclass",parameters,context,feedback)
     
 def applyRNull(in_path,new_val,out_path,context=None,feedback=None):
@@ -1069,7 +1079,7 @@ def applyRBuffer(in_path,buffer_vals,out_path,context=None,feedback=None):
                     'units' : 0, # 0 = meters ?
                     #'memory' : 5000,
                     'GRASS_RASTER_FORMAT_META' : '',
-                    'GRASS_RASTER_FORMAT_OPT' : '',
+                    'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
                     #'GRASS_REGION_CELLSIZE_PARAMETER' : 25,
                     'GRASS_REGION_PARAMETER' : None,
                     '-z' : False,
@@ -1093,7 +1103,7 @@ def applyRCost(start_path,cost_path,cost,out_path,context=None,feedback=None):
                     'memory' : 5000,
                     'GRASS_MIN_AREA_PARAMETER' : 0.0001, 
                     'GRASS_RASTER_FORMAT_META' : '',
-                    'GRASS_RASTER_FORMAT_OPT' : '',
+                    'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
                     #'GRASS_REGION_CELLSIZE_PARAMETER' : 0,
                     'GRASS_REGION_PARAMETER' : None,
                     'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
@@ -1112,7 +1122,7 @@ def applyRSeries(layers,aggr_func,output,range=None,context=None,feedback=None):
                    '-n' : False,
                    '-z' : False,
                    'GRASS_RASTER_FORMAT_META' : '',
-                   'GRASS_RASTER_FORMAT_OPT' : '',
+                   'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
                    'GRASS_REGION_CELLSIZE_PARAMETER' : 0,
                    'GRASS_REGION_PARAMETER' : None,
                    'input' : layers,
@@ -1166,14 +1176,16 @@ def applyRasterizationCmd(in_path,field,out_path,extent_path,
                   '-of','GTiff']
                   #'-a_nodata',nodata_val]
     if to_byte:
-        parameters += ['-ot', 'Int16','-a_nodata',nodata_val]
+        parameters.extend(['-ot', 'Int16','-a_nodata',nodata_val])
     if field == "geom":
-        parameters += ['-burn', '1']
+        parameters.extend(['-burn', '1'])
     else:
-        parameters += ['-a',field]
-    parameters += more_args
-    parameters += [in_path,out_path]
-    utils.debug("rasteization cmd = " + str(parameters))
+        parameters.extend(['-a',field])
+    for opt in GTIFF_COPT:
+        parameters.extend(['-co', opt])
+    parameters.extend(more_args)
+    parameters.extend([in_path,out_path])
+    utils.debug("rasterization cmd = " + str(parameters))
     p = subprocess.Popen(parameters,stderr=subprocess.PIPE)
     out,err = p.communicate()
     utils.debug(str(p.args))
@@ -1222,11 +1234,13 @@ def applyWarpGdal(in_path,out_path,resampling_mode,
                 #'-dstnodata',nodata_val,
                 #'-ot','Int16',
                 '-overwrite']
+    for opt in GTIFF_COPT:
+        cmd_args.extend(['-co', opt])
     if resampling_mode:
-        cmd_args += ['-r',resampling_mode]
+        cmd_args.extend(['-r', resampling_mode])
     if to_byte:
-        cmd_args += ['-dstnodata',nodata_val]
-        cmd_args += ['-ot','Int16']
+        cmd_args.extend(['-dstnodata', nodata_val])
+        cmd_args.extend(['-ot','Int16'])
     #cmd_args += more_args
     cmd_args += [in_path, out_path]
     utils.executeCmd(cmd_args)
@@ -1240,6 +1254,7 @@ def applyReclassProcessing(in_path,out_path,rules_file,title):
                   'output' : out_path,
                   'rules' : rules_file,
                   'title' : title,
+                   'GRASS_RASTER_FORMAT_OPT': ','.join(GTIFF_COPT),
                    'GRASS_REGION_CELLSIZE_PARAMETER' : 50,
                    'GRASS_SNAP_TOLERANCE_PARAMETER' : -1,
                    'GRASS_MIN_AREA_PARAMETER' : 0}
@@ -1269,13 +1284,14 @@ def applyGdalCalc(in_path,out_path,expr,type='Int32',nodata=nodata_val,
         cmd_args = ['gdal_calc.py']
     # gdal_calc_cmd = 'gdal_calc.bat' if utils.platform_sys == 'Windows' else 'gdal_calc.py'
     utils.debug("cmd_args commnad = " + str(cmd_args))
-    cmd_args += [
+    cmd_args.extend([
                 '-A', in_path,
                 '--type=' + str(type),
                 '--outfile=' + out_path,
                 '--NoDataValue=' + str(nodata),
-                '--overwrite']
-    cmd_args += more_args
+                '--overwrite'])
+    cmd_args.extend(['--co', " ".join(GTIFF_COPT)])
+    cmd_args.extend(more_args)
     expr_opt = '--calc=' + expr
     # expr_opt = '--calc="A*2"'
     cmd_args.append(expr_opt)
@@ -1317,6 +1333,7 @@ def applyGdalCalcAB_ANull(in_path1,in_path2,out_path,expr,load_flag=False):
                 '--overwrite',
                 '--outfile='+out_path]
     expr_opt = '--calc=' + str(expr)
+    cmd_args.extend(['--co', " ".join(GTIFF_COPT)])
     cmd_args.append(expr_opt)
     utils.executeCmd(cmd_args)
     if load_flag:
@@ -1375,6 +1392,7 @@ def applyPonderationGdal(a_path,b_path,out_path,pos_values=False):
         expr_opt = '--calc=A*B*less_equal(0,A)*less_equal(0,B)'
     else:
         expr_opt = '--calc=A*B'
+    cmd_args.extend(['--co', " ".join(GTIFF_COPT)])
     cmd_args.append(expr_opt)
     utils.executeCmd(cmd_args)
     res_layer = qgsUtils.loadRasterLayer(out_path)
@@ -1400,6 +1418,7 @@ def applyGdalMerge(files,out_path,load_flag=False):
                 '-ot','Int32',
                 '-n', nodata_val,
                 '-a_nodata', nodata_val]
+    cmd_args.extend(['--co', " ".join(GTIFF_COPT)])
     cmd_args += files
     utils.executeCmd(cmd_args)
     if load_flag:

--- a/qgsTreatments.py
+++ b/qgsTreatments.py
@@ -776,14 +776,13 @@ def applyWarpReproject(in_path,out_path,resampling_mode='near',dst_crs=None,
     return applyProcessingAlg("gdal","warpreproject",parameters,context,feedback)
     
 def applyTranslate(in_path,out_path,data_type=USE_INPUT_TYPE,nodata_val=nodata_val,
-                   crs=None,options='',context=None,feedback=None):
+                   crs=None,context=None,feedback=None):
     feedback.setProgressText("Tanslate")
     # data type 0 = input raster type
     parameters = { 'COPY_SUBDATASETS' : False,
                    'DATA_TYPE' : qgsTypeToInt(data_type),
                    'INPUT' : in_path,
                    'NODATA' : nodata_val,
-                   'OPTIONS': options,
                    'OUTPUT' : out_path,
                    'OPTIONS' : '|'.join(GTIFF_COPT),
                    'TARGET_CRS' : None }
@@ -917,7 +916,7 @@ def applyRasterCalcAB(input_a,input_b,output,expr,
                context=context,feedback=feedback)
 
 def applyRasterCalcABC(input_a,input_b,input_c, band_a, band_b, band_c, output,expr,
-                    nodata_val=None,out_type=Qgis.Float32,options='',
+                    nodata_val=None,out_type=Qgis.Float32,
                     context=None,feedback=None):
     TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
     parameters = { 'BAND_A' : band_a,
@@ -928,7 +927,7 @@ def applyRasterCalcABC(input_a,input_b,input_c, band_a, band_b, band_c, output,e
                    'INPUT_B' : input_b,
                    'INPUT_C' : input_c,
                    'NO_DATA' : nodata_val,
-                   'OPTIONS': options,
+                   'OPTIONS' : '|'.join(GTIFF_COPT),
                    'OUTPUT' : output,
                    'RTYPE' : qgsTypeToInt(out_type,shift=True) }
     return applyProcessingAlg("gdal","rastercalculator",parameters,context,feedback)
@@ -1446,13 +1445,13 @@ def applyGetLayerExtent(input_raster, output, context=None,feedback=None):
     }
     return applyProcessingAlg("native","polygonfromlayerextent", parameters,context,feedback)
     
-def applyClipRasterByExtent(input_raster, input_extent, output, options='', context=None,feedback=None):
+def applyClipRasterByExtent(input_raster, input_extent, output, context=None,feedback=None):
     parameters = {
         'DATA_TYPE': 0,  # Utiliser le type de donnée de la couche en entrée
         'EXTRA': '',
         'INPUT': input_raster,
         'NODATA': None,
-        'OPTIONS': options,
+        'OPTIONS' : '|'.join(GTIFF_COPT),
         'OVERCRS': False,
         'PROJWIN': input_extent,
         'OUTPUT': output

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -40,7 +40,7 @@ from PyQt5.QtWidgets import QFileDialog
 from . import utils
 
 
-if os.environ.has_key("GTIFF_COPT"):
+if os.environ.get("GTIFF_COPT") is not None:
     GTIFF_COPT = os.environ["GTIFF_COPT"].split()
 else:
     GTIFF_COPT = ["BIGTIFF=IF_SAFER", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -43,7 +43,7 @@ from . import utils
 if os.environ.has_key("GTIFF_COPT"):
     GTIFF_COPT = os.environ["GTIFF_COPT"].split()
 else:
-    GTIFF_COPT = ["BIGTIFF=IF_SAFER", "TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
+    GTIFF_COPT = ["BIGTIFF=IF_SAFER", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
 
 
 def typeIsInteger(t):

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -39,7 +39,11 @@ from PyQt5.QtWidgets import QFileDialog
 
 from . import utils
 
-DEFAULT_GTIFF_COPT = ["TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
+
+if os.environ.has_key("GTIFF_COPT"):
+    GTIFF_COPT = os.environ["GTIFF_COPT"].split()
+else:
+    GTIFF_COPT = ["TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
 
 
 def typeIsInteger(t):
@@ -479,7 +483,7 @@ def getLayerAssocs(layer,key_field,val_field):
 # Code snippet from https://github.com/Martin-Jung/LecoS/blob/master/lecos_functions.py
 # Exports array to .tif file (path) according to rasterSource
 def exportRaster(array,rasterSource,path,
-                 nodata=None,type=None, copt=DEFAULT_GTIFF_COPT):
+                 nodata=None,type=None, copt=GTIFF_COPT):
     raster = gdal.Open(str(rasterSource))
     rows = raster.RasterYSize
     cols = raster.RasterXSize

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -43,7 +43,7 @@ from . import utils
 if os.environ.has_key("GTIFF_COPT"):
     GTIFF_COPT = os.environ["GTIFF_COPT"].split()
 else:
-    GTIFF_COPT = ["TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
+    GTIFF_COPT = ["BIGTIFF=IF_SAFER", "TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
 
 
 def typeIsInteger(t):

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -483,7 +483,7 @@ def getLayerAssocs(layer,key_field,val_field):
 # Code snippet from https://github.com/Martin-Jung/LecoS/blob/master/lecos_functions.py
 # Exports array to .tif file (path) according to rasterSource
 def exportRaster(array,rasterSource,path,
-                 nodata=None,type=None, copt=GTIFF_COPT):
+                 nodata=None,type=None,copt=GTIFF_COPT):
     raster = gdal.Open(str(rasterSource))
     rows = raster.RasterYSize
     cols = raster.RasterXSize

--- a/qgsUtils.py
+++ b/qgsUtils.py
@@ -39,6 +39,9 @@ from PyQt5.QtWidgets import QFileDialog
 
 from . import utils
 
+DEFAULT_GTIFF_COPT = ["TILED=YES", "COMPRESS=LZW", "NUM_THREADS=ALL_CPUS"]
+
+
 def typeIsInteger(t):
     return (t == QVariant.Int
             or t == QVariant.UInt
@@ -476,7 +479,7 @@ def getLayerAssocs(layer,key_field,val_field):
 # Code snippet from https://github.com/Martin-Jung/LecoS/blob/master/lecos_functions.py
 # Exports array to .tif file (path) according to rasterSource
 def exportRaster(array,rasterSource,path,
-                 nodata=None,type=None):
+                 nodata=None,type=None, copt=DEFAULT_GTIFF_COPT):
     raster = gdal.Open(str(rasterSource))
     rows = raster.RasterYSize
     cols = raster.RasterXSize
@@ -487,12 +490,15 @@ def exportRaster(array,rasterSource,path,
         out_nodata = nodata
     if type:
         out_type = type
+    if copt is None:
+        copt = []
+    elif not isinstance(copt, list):
+        utils.internal_error("Could not apply GDAL creation options : " + str(copt))
 
     driver = gdal.GetDriverByName('GTiff')
     # Create File based in path
     try:
-        #outDs = driver.Create(path, cols, rows, 1, gdal.GDT_Byte)
-        outDs = driver.Create(path, cols, rows, 1, out_type)
+        outDs = driver.Create(path, cols, rows, 1, out_type, copt)
     except RuntimeError:
         utils.internal_error("Could not overwrite file. Check permissions!")
     if outDs is None:


### PR DESCRIPTION
Fix https://github.com/MathieuChailloux/qgis_lib_mc/issues/3.
This PR adds LZW compression and tiling to every raster output (if generated using grass: or gdal: algorithms).
The default creation options are defined in the GTIFF_COPT constant in qgsUtils.py